### PR TITLE
Added cross-tomographic computation for Map3

### DIFF
--- a/Map3/exampleMap3Measurement.ipynb
+++ b/Map3/exampleMap3Measurement.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "In this notebook we demonstrate how to use the Map³-measurement for convergence-healpy maps. The measurement method is based on FFT.\n",
     "\n",
-    "Author: Laila Linke\n",
+    "Authors: Laila Linke, Lucas Porth\n",
     "\n",
     "The Map3 measurement code was developed together with Sven Heydenreich and Pierre Burger"
    ]
@@ -70,7 +70,7 @@
    "id": "a4a5e052-e53d-4897-a9be-78b99e04e7d9",
    "metadata": {},
    "source": [
-    "The following code will go through all possible combinations of nshells, nsides, tomobins and seeds and measure the Map3 for the relevant HACC convergence maps. The output is written into the folder `Results`."
+    "The following code will go through all relevant combinations of nshells, nsides, tomobin combinations and seeds and measure the Map3 for the relevant HACC convergence maps. The output is written into the folder `Results`."
    ]
   },
   {
@@ -145,24 +145,35 @@
     "        print(f\"Using nshell {nshell}\")\n",
     "        for seed in seeds:\n",
     "            print(f\"Using seed {seed}\")\n",
-    "            for tomobin in tomobins:\n",
-    "                print(f\"Using tomobin {tomobin}\")\n",
+    "            # As Map3(theta1,theta2,theta3,z1,z2,z3) is independent under permutations of the theta_i and zi\n",
+    "            # we choose z1<=z2<=z3 in this loop and theta1<=theta2<=theta3 in the \n",
+    "            # `measureMap3FromKappa_crossbins` function\n",
+    "            for elt1,tomobin1 in enumerate(tomobins):\n",
+    "                for elt2,tomobin2 in enumerate(tomobins[elt1:]):\n",
+    "                    for elt3,tomobin3 in enumerate(tomobins[elt1+elt2:]):\n",
+    "                        print(f\"Using tomobins {tomobin1,tomobin2,tomobin3}\")\n",
     "\n",
-    "                # Directories for data and output\n",
-    "                dir_data=f\"/global/cscratch1/sd/xuod/HOS_sims/L845/HACC150/shells_z{nshell}_subsampleauto_groupiso/kappa_Euclid_dndz_fu08_bin1-5/\"\n",
-    "                dir_results='Results/'\n",
+    "                        # Directories for data and output\n",
+    "                        dir_data=f\"/global/cscratch1/sd/xuod/HOS_sims/L845/HACC150/shells_z{nshell}_subsampleauto_groupiso/kappa_Euclid_dndz_fu08_bin1-5/\"\n",
+    "                        dir_results='Results/'\n",
     "\n",
-    "                # Input filename\n",
-    "                fn_map=dir_data+f\"kappa_hacc_nz{tomobin}_nside4096_seed{seed}.fits\"\n",
-    "                #Output filename\n",
-    "                fn_out=dir_results+f\"Map3_HACC_KappaMap_curved_nside_{nside}_nshells_{nshell}_tomo_{tomobin}_seed_{seed}.dat\"\n",
-    "    \n",
-    "                # Read healsparse map and convert it to healpix\n",
-    "                hsp_kappa=healsparse.HealSparseMap.read(fn_map)\n",
-    "                kappa=hsp_kappa.generate_healpix_map()\n",
+    "                        # Input filenames\n",
+    "                        fn_map1=dir_data+f\"kappa_hacc_nzs{tomobin1}_nside4096_seed{seed}.fits\"\n",
+    "                        fn_map2=dir_data+f\"kappa_hacc_nzs{tomobin2}_nside4096_seed{seed}.fits\"\n",
+    "                        fn_map3=dir_data+f\"kappa_hacc_nzs{tomobin3}_nside4096_seed{seed}.fits\"\n",
+    "                        #Output filename\n",
+    "                        fn_out=dir_results+f\"Map3_HACC_KappaMap_curved_nside_{nside}_nshells_{nshell}_tomo_{tomobin1}_{tomobin2}_{tomobin3}_seed_{seed}.dat\"\n",
     "\n",
-    "                # Do measurement\n",
-    "                measureMap3FromKappa(kappa, thetas=thetas, nside=nside, fn_out=fn_out, verbose=False, doPlots=False)"
+    "                        # Read healsparse map1 and convert them to healpix\n",
+    "                        hsp_kappa1=healsparse.HealSparseMap.read(fn_map1)\n",
+    "                        kappa1=hsp_kappa1.generate_healpix_map()\n",
+    "                        hsp_kappa2=healsparse.HealSparseMap.read(fn_map2)\n",
+    "                        kappa2=hsp_kappa2.generate_healpix_map()\n",
+    "                        hsp_kappa3=healsparse.HealSparseMap.read(fn_map3)\n",
+    "                        kappa3=hsp_kappa3.generate_healpix_map()\n",
+    "\n",
+    "                        # Do measurement\n",
+    "                        measureMap3FromKappa_crossbins(kappa1, kappa2, kappa3, thetas=thetas, nside=nside, fn_out=fn_out, verbose=False, doPlots=False)"
    ]
   },
   {


### PR DESCRIPTION
Added capability to compute Map3 in tomographic bins. In particular, added the function `measureMap3FromKappa_crossbins` to `Map3/aperture_mass_computer.py`, which takes three different kappa maps as an input. Also updated the notebook `Map3/exampleMap3Measurement.ipynb` on how this function can be used on the HACC convergence maps.